### PR TITLE
Exemplo de tag `<input>` com tipagem genérica

### DIFF
--- a/src/components/form/Form.vue
+++ b/src/components/form/Form.vue
@@ -1,7 +1,24 @@
 <template>
   <div>
+
+    <!-- use `v-for` para efetuar um loop dentro do template -->
+    <!--     `Object.keys(data)` retorna um array com os nomes de cada atributo do objeto `data` -->
     <div v-for="(key, index) in Object.keys(data)" :key="index">
+
+      <!-- `key` é o nome do atributo -->
+      <!--     chaves duplas `{{ }}` são usadas para inserir valores de variaveis dentro do template -->
       <label>{{ key }}</label>
+
+      <!-- :type define o tipo do input -->
+      <!--    nesse caso estamos chamando a função `getFormFieldInputType` que retorna o tipo do input baseado no valor do atributo -->
+      <!--    mas também é possível usar `:type="typeof data[key]"` caso não seja necessário um tratamento especial (diferenciar apenas text e number por ex) -->
+      <!--    ou `:type="data[key] instanceof Date ? 'date' : typeof data[key]"` para tratar o caso de ser uma data, etc -->
+      <!-- :value define o valor que estará sendo exibido no input ao ser renderizado -->
+      <!--    `data[key]` faz com que o valor seja puxado do atributo de nome `key` do objeto `data` -->
+      <!-- @input é um evento que é disparado quando o valor do input é alterado, assim como o onChange do React -->
+      <!--    `onChangeFunctions[key]` é um objeto que contém funções que são chamadas quando o valor do input é alterado -->
+      <!--    $event.target.value é o valor que foi inserido no input -->
+      <!--    ou seja, estamos chamando a função `onChangeFunctions[key]` passando o objeto `data` e o valor inserido no input -->
       <input
         :type="getFormFieldInputType(data, key)"
         :value="data[key]"

--- a/src/components/form/Form.vue
+++ b/src/components/form/Form.vue
@@ -3,7 +3,7 @@
     <div v-for="(key, index) in Object.keys(data)" :key="index">
       <label>{{ key }}</label>
       <input
-        :type="utils.data[key] instanceof Date ? 'date' : typeof data[key]"
+        :type="getFormFieldInputType(data, key)"
         :value="data[key]"
         @input="onChangeFunctions[key](data, $event.target.value)"
       >
@@ -12,6 +12,19 @@
 </template>
 
 <script lang="ts">
+function getFormFieldInputType(data: Object, key: string): string {
+  if (data[key] instanceof Date) {
+    return 'date';
+  }
+
+  switch (typeof data[key]) {
+    case 'boolean':
+      return 'checkbox';
+    default:
+      return typeof data[key];
+  }
+}
+
 export default {
   props: {
     data: {
@@ -22,7 +35,12 @@ export default {
       type: Object,
       required: true,
     },
-  }
+  },
+  setup() {
+    return {
+      getFormFieldInputType,
+    };
+  },
 }
 </script>
 

--- a/src/components/form/Form.vue
+++ b/src/components/form/Form.vue
@@ -1,0 +1,29 @@
+<template>
+  <div>
+    <div v-for="(key, index) in Object.keys(data)" :key="index">
+      <label>{{ key }}</label>
+      <input
+        :type="utils.data[key] instanceof Date ? 'date' : typeof data[key]"
+        :value="data[key]"
+        @input="onChangeFunctions[key](data, $event.target.value)"
+      >
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+export default {
+  props: {
+    data: {
+      type: Object,
+      required: true,
+    },
+    onChangeFunctions: {
+      type: Object,
+      required: true,
+    },
+  }
+}
+</script>
+
+<style scoped></style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,8 +1,14 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import PartnerDashboard from '../views/PartnerDashboard.vue';
 import TrackDashboard from '../views/TrackDashboard.vue';
+import FormExample from '../views/FormExample.vue';
 
 const routes = [
+  {
+    path: '/',
+    name: 'Form Example',
+    component: FormExample,
+  },
   {
     path: '/partner',
     name: 'Partner',

--- a/src/service/PartnerService.ts
+++ b/src/service/PartnerService.ts
@@ -9,6 +9,10 @@ import axios from 'axios';
 const API_URL: string = 'http://localhost:8080';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
+export async function getDataMocked () {
+  return [];
+}
+
 export async function parsePartner(partner: any): Promise<PartnerSchema> {
   return {
     id: partner.id,

--- a/src/views/FormExample.vue
+++ b/src/views/FormExample.vue
@@ -1,0 +1,55 @@
+<template>
+  <Form
+    :data="formData"
+    :onChangeFunctions="formDataOnChange"
+  />
+</template>
+
+<script lang="ts">
+import Form from '../components/form/Form.vue';
+
+type TestDataType = {
+  name: string;
+  age: number;
+  favDate: Date;
+  isAlive: boolean;
+};
+
+const formData: TestDataType = {
+  name: 'John Doe',
+  age: 57,
+  favDate: new Date(),
+  isAlive: true,
+};
+
+const formDataOnChange = {
+  name: (object: TestDataType, value: string) => {
+    console.log('Name changed to:', value);
+    return object.name = value
+  },
+  age: (object: TestDataType, value: number) => {
+    console.log('Age changed to:', value);
+    return object.age = value
+  },
+  favDate: (object: TestDataType, value: Date) => {
+    console.log('Fav date changed to:', value);
+    return object.favDate = value
+  },
+  isAlive: (object: TestDataType, value: boolean) => {
+    console.log('Is alive changed to:', value);
+    return object.isAlive = value
+  },
+}
+
+export default {
+  components: {
+    Form,
+  },
+  setup() {
+    return {
+      formData,
+      formDataOnChange,
+    };
+  },
+};
+</script>


### PR DESCRIPTION
# Objetivo:
`Qual o propósito / escopo dessas alterações?`

- Exemplificar a implementação de input tipado de forma genérica de acordo com os atributos de um objeto arbitrário parametrizado;
  - Utilizando `Object.keys()`, conseguimos fazer um loop (`v-for`) para popular os campos do objeto;
  - Conseguimos acessar o valor do atributo no objeto utilizando o iterador do `v-for` (nesse caso `key`);
  - Através do parâmetro `:type` da tag `<input>` podemos especificar o tipo do input, alterando a forma que o usuário preenche aquele valor;
  - Podemos passar valores arbitrários para o parâmetro `:type` e, consequentemente, implementar lógica (nesse caso a função `getFormFieldInputType`) para decidir dinamicamente o valor a ser atribuído a este parâmetro;
- Exemplificar função parametrizada para o `onChange` de input para a execução arbitrária de código ao alterar valores dos campos;
  - Em caso real, podemos passar a função que altera um objeto salvo em um contexto acima. Podemos então, utilizar esse objeto para efetuar uma chamada a uma função do `Service` para interagir com o banco de dados (exemplo);

# Solução:
`Quais estratégias foram adotadas durante as alterações em questão?`

- Criação do componente `Form`;
- Tela para exemplo e roteamento;
- Inclusão de comentários explicando a lógica implementada.

<div align="center">
  <img src="https://github.com/projetoKhali/api4front/assets/93501477/e7981a86-5d71-4673-8835-b2f3a2eb11c6">
  <br>
  <img src="https://github.com/projetoKhali/api4front/assets/93501477/7387fafa-569d-4dc1-b72c-aa0c80d08e18">
</div>