### PR TITLE
fix: paginar funções `service`

### DIFF
--- a/src/schemas/Page.ts
+++ b/src/schemas/Page.ts
@@ -1,0 +1,44 @@
+export class Page<T> {
+  content: T[];
+  index: number;
+  totalPages: number;
+  totalElements: number;
+  first: boolean;
+  last: boolean;
+  size: number;
+
+  constructor(
+    content: T[],
+    number: number,
+    totalPages: number,
+    totalElements: number,
+    first: boolean,
+    last: boolean,
+    size: number,
+  ) {
+    this.content = content;
+    this.index = number;
+    this.totalPages = totalPages;
+    this.totalElements = totalElements;
+    this.first = first;
+    this.last = last;
+    this.size = size;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static from<T>(response: any): Page<T> {
+    return new Page<T>(
+      response.content,
+      response.number,
+      response.totalPages,
+      response.totalElements,
+      response.first,
+      response.last,
+      response.size,
+    );
+  }
+
+  static empty<T>(): Page<T> {
+    return new Page<T>([], 0, 0, 0, true, true, 0);
+  }
+}

--- a/src/service/PartnerService.ts
+++ b/src/service/PartnerService.ts
@@ -10,6 +10,7 @@ import { PartnerExpertiseSchema } from '@/schemas/partner/PartnerExpertise';
 import { PartnerQualifierSchema } from '@/schemas/partner/PartnerQualifier';
 
 const API_URL: string = 'http://localhost:8080';
+const DEFAULT_PAGE_SIZE: number = 10;
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export async function parsePartner(partner: any): Promise<PartnerSchema> {
@@ -38,8 +39,13 @@ export async function mapPartners(partners: any): Promise<PartnerSchema[]> {
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
-export async function getPartners(): Promise<PartnerSchema[]> {
-  const response = await axios.get(`${API_URL}/partners`);
+export async function getPartners(
+  page?: number,
+  size?: number,
+): Promise<PartnerSchema[]> {
+  const response = await axios.get(
+    `${API_URL}/partners/list?page=${page || 0}&size=${size || DEFAULT_PAGE_SIZE}`,
+  );
   return mapPartners(response.data);
 }
 

--- a/src/service/PartnerService.ts
+++ b/src/service/PartnerService.ts
@@ -8,6 +8,7 @@ import { PartnerSchemaDashboard } from '../schemas/partner/Partner';
 import axios from 'axios';
 import { PartnerExpertiseSchema } from '@/schemas/partner/PartnerExpertise';
 import { PartnerQualifierSchema } from '@/schemas/partner/PartnerQualifier';
+import { Page } from '../schemas/Page';
 
 const API_URL: string = 'http://localhost:8080';
 const DEFAULT_PAGE_SIZE: number = 10;
@@ -34,7 +35,7 @@ export async function parsePartner(partner: any): Promise<PartnerSchema> {
 
 export async function mapPartners(partners: any): Promise<PartnerSchema[]> {
   return partners
-    ? await partners.map(async (item: any) => parsePartner(item))
+    ? await Promise.all(partners.map(async (p: any) => await parsePartner(p)))
     : [];
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
@@ -42,11 +43,14 @@ export async function mapPartners(partners: any): Promise<PartnerSchema[]> {
 export async function getPartners(
   page?: number,
   size?: number,
-): Promise<PartnerSchema[]> {
+): Promise<Page<PartnerSchema>> {
   const response = await axios.get(
-    `${API_URL}/partners/list?page=${page || 0}&size=${size || DEFAULT_PAGE_SIZE}`,
+    `${API_URL}/partner/list?page=${page || 0}&size=${size || DEFAULT_PAGE_SIZE}`,
   );
-  return mapPartners(response.data);
+  return Page.from<PartnerSchema>({
+    ...response.data,
+    content: await mapPartners(response.data.content),
+  });
 }
 
 export async function getPartner(id: number): Promise<PartnerSchema> {

--- a/src/service/UserService.ts
+++ b/src/service/UserService.ts
@@ -1,4 +1,5 @@
 import { UserSchema, UserPostSchema, UserPatchSchema } from '../schemas/User';
+import { Page } from '../schemas/Page';
 import axios from 'axios';
 
 const API_URL: string = 'http://localhost:8080';
@@ -14,19 +15,24 @@ export async function parseUser(user: any): Promise<UserSchema> {
   };
 }
 
-export async function mapUsers(user: any): Promise<UserSchema[]> {
-  return user ? await user.map(async (item: any) => parseUser(item)) : [];
+export async function mapUsers(users: any): Promise<UserSchema[]> {
+  return users
+    ? Promise.all(users.map(async (item: any) => await parseUser(item)))
+    : [];
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 export async function getUsers(
   page?: number,
   size?: number,
-): Promise<UserSchema[]> {
+): Promise<Page<UserSchema>> {
   const response = await axios.get(
     `${API_URL}/user/list?page=${page || 0}&size=${size || DEFAULT_PAGE_SIZE}`,
   );
-  return mapUsers(response.data);
+  return Page.from<UserSchema>({
+    ...response.data,
+    content: await mapUsers(response.data.content),
+  });
 }
 
 export async function getUser(id: number): Promise<UserSchema> {

--- a/src/service/UserService.ts
+++ b/src/service/UserService.ts
@@ -2,6 +2,7 @@ import { UserSchema, UserPostSchema, UserPatchSchema } from '../schemas/User';
 import axios from 'axios';
 
 const API_URL: string = 'http://localhost:8080';
+const DEFAULT_PAGE_SIZE: number = 10;
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export async function parseUser(user: any): Promise<UserSchema> {
@@ -18,8 +19,13 @@ export async function mapUsers(user: any): Promise<UserSchema[]> {
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
-export async function getUsers(): Promise<UserSchema[]> {
-  const response = await axios.get(`${API_URL}/user`);
+export async function getUsers(
+  page?: number,
+  size?: number,
+): Promise<UserSchema[]> {
+  const response = await axios.get(
+    `${API_URL}/user/list?page=${page || 0}&size=${size || DEFAULT_PAGE_SIZE}`,
+  );
   return mapUsers(response.data);
 }
 

--- a/src/views/ListPartner.vue
+++ b/src/views/ListPartner.vue
@@ -49,28 +49,26 @@ const tableHeaders = [
   'Edição',
 ];
 
-const fullData = ref<
-  Array<
-    [
-      number,
-      string,
-      string,
-      string,
-      string,
-      string,
-      string,
-      string,
-      string,
-      string,
-      string,
-      string,
-      string,
-      string,
-      Function,
-      Function,
-    ]
-  >
->([]);
+type PartnerTableRow = [
+  number,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  Function,
+  Function,
+];
+
+const fullData = ref<PartnerTableRow[]>([]);
 const itemsPerPage: number = 10;
 const isPopupOpen = ref(false);
 const partner = ref<PartnerSchema | PartnerPostSchema>();
@@ -88,26 +86,7 @@ const fetchData = async () => {
   try {
     const response = await fetch('http://localhost:8080/partner/list');
     const data = await response.json();
-    const formatted: Array<
-      [
-        number,
-        string,
-        string,
-        string,
-        string,
-        string,
-        string,
-        string,
-        string,
-        string,
-        string,
-        string,
-        string,
-        string,
-        Function,
-        Function,
-      ]
-    > = data.content.map((item: PartnerSchema) => [
+    const formatted: Array<PartnerTableRow> = data.content.map((item: PartnerSchema) => [
       item.id,
       item.companyId,
       item.name,
@@ -151,26 +130,7 @@ const pagination = {
   getTotalPages: () => Math.ceil(fullData.value.length / itemsPerPage),
   getPageData: (
     pageIndex: number,
-  ): Array<
-    [
-      number,
-      string,
-      string,
-      string,
-      string,
-      string,
-      string,
-      string,
-      string,
-      string,
-      string,
-      string,
-      string,
-      string,
-      Function,
-      Function,
-    ]
-  > => {
+  ): Array<PartnerTableRow> => {
     const startIndex = pageIndex * itemsPerPage;
     const endIndex = startIndex + itemsPerPage;
     return fullData.value.slice(startIndex, endIndex);

--- a/src/views/ListPartner.vue
+++ b/src/views/ListPartner.vue
@@ -94,36 +94,38 @@ const fetchData = async (pageIndex: number) => {
     totalPages.value = partnersPage.totalPages;
 
     const data = partnersPage.content;
-    const formatted: Array<PartnerTableRow> = data.map((item: PartnerSchema) => [
-      item.id,
-      item.companyId,
-      item.name,
-      item.adminName,
-      item.adminEmail,
-      item.slogan,
-      item.country,
-      item.city,
-      item.address,
-      item.compliance ? 'Sim' : 'Não',
-      item.credit ? 'Sim' : 'Não',
-      item.status ? 'Ativo' : 'Inativo',
-      item.memberType ? 'Sim' : 'Não',
-      formatDate(item.firstDateMembership),
-      `/partner/${item.id}`,
-      () => {
-        partner.value = item;
-        isPopupOpen.value = !isPopupOpen.value;
-        console.log('Print', partner);
-        actions.value = {
-          salvar: (_: PartnerSchema) => {
-            if (partner.value === undefined) return;
-            // const {id, ...partnerData} = partner.value;
-            updatePartner(partner.value.id, partner.value);
-            console.log('Valor partner', partner.value);
-          },
-        };
-      },
-    ]);
+    const formatted: Array<PartnerTableRow> = data.map(
+      (item: PartnerSchema) => [
+        item.id,
+        item.companyId,
+        item.name,
+        item.adminName,
+        item.adminEmail,
+        item.slogan,
+        item.country,
+        item.city,
+        item.address,
+        item.compliance ? 'Sim' : 'Não',
+        item.credit ? 'Sim' : 'Não',
+        item.status ? 'Ativo' : 'Inativo',
+        item.memberType ? 'Sim' : 'Não',
+        formatDate(item.firstDateMembership),
+        `/partner/${item.id}`,
+        () => {
+          partner.value = item;
+          isPopupOpen.value = !isPopupOpen.value;
+          console.log('Print', partner);
+          actions.value = {
+            salvar: (_: PartnerSchema) => {
+              if (partner.value === undefined) return;
+              // const {id, ...partnerData} = partner.value;
+              updatePartner(partner.value.id, partner.value);
+              console.log('Valor partner', partner.value);
+            },
+          };
+        },
+      ],
+    );
     fullData.value = formatted;
   } catch (error) {
     console.error('Erro ao buscar dados da API:', error);
@@ -134,9 +136,7 @@ onMounted(() => fetchData(0));
 
 const pagination = {
   getTotalPages: () => totalPages.value,
-  getPageData: (
-    pageIndex: number,
-  ): Array<PartnerTableRow> => {
+  getPageData: (pageIndex: number): Array<PartnerTableRow> => {
     return fetchData(pageIndex);
   },
 };

--- a/src/views/ListUser.vue
+++ b/src/views/ListUser.vue
@@ -25,7 +25,7 @@
 import { ref, onMounted } from 'vue';
 import Table from '../components/Table.vue';
 import { UserSchema, UserPostSchema } from '@/schemas/User';
-import { createUser, updateUser } from '../service/UserService';
+import { getUsers, createUser, updateUser } from '../service/UserService';
 import FormPopup from '../components/form/FormPopup.vue';
 
 const tableHeaders = ['ID', 'Email', 'Nome', 'Type', 'Edição'];
@@ -34,17 +34,21 @@ const fullData = ref<
   Array<[number, string, string, string, string, Function, Function]>
 >([]);
 const itemsPerPage: number = 10;
+const totalPages = ref(0);
 const isPopupOpen = ref(false);
 const user = ref<UserSchema | UserPostSchema>();
 const actions = ref<{ salvar: (user: UserSchema) => void }>();
 
-const fetchData = async () => {
+const fetchData = async (pageIndex: number) => {
   try {
-    const response = await fetch('http://localhost:8080/user/list');
-    const data = await response.json();
+    const usersPage = await getUsers(pageIndex, itemsPerPage);
+
+    totalPages.value = usersPage.totalPages;
+
+    const data = usersPage.content;
     const formatted: Array<
       [number, string, string, string, string, Function, Function]
-    > = data.content.map((item: UserSchema) => [
+    > = data.map((item: UserSchema) => [
       item.id,
       item.login,
       item.name,
@@ -55,10 +59,7 @@ const fetchData = async () => {
         console.log('Print', user);
         actions.value = {
           salvar: (_: UserSchema) => {
-            if (user.value === undefined) {
-              return;
-            }
-            // const {id, ...userData} = user.value;
+            if (user.value === undefined) return
             updateUser(user.value.id, user.value);
             console.log('Valor user', user.value);
           },
@@ -71,16 +72,14 @@ const fetchData = async () => {
   }
 };
 
-onMounted(fetchData);
+onMounted(() => fetchData(0));
 
 const pagination = {
-  getTotalPages: () => Math.ceil(fullData.value.length / itemsPerPage),
+  getTotalPages: () => totalPages.value,
   getPageData: (
     pageIndex: number,
   ): Array<[number, string, string, string, string, Function, Function]> => {
-    const startIndex = pageIndex * itemsPerPage;
-    const endIndex = startIndex + itemsPerPage;
-    return fullData.value.slice(startIndex, endIndex);
+    return fetchData(pageIndex);
   },
 };
 

--- a/src/views/ListUser.vue
+++ b/src/views/ListUser.vue
@@ -59,7 +59,7 @@ const fetchData = async (pageIndex: number) => {
         console.log('Print', user);
         actions.value = {
           salvar: (_: UserSchema) => {
-            if (user.value === undefined) return
+            if (user.value === undefined) return;
             updateUser(user.value.id, user.value);
             console.log('Valor user', user.value);
           },


### PR DESCRIPTION
### Você rodou o comando `yarn lint:fix` *ou* `npm run lint:fix` antes de abrir o PR?
`Se não, rode o comando e faça um novo commit incluindo as correções resultantes.`

- [x] Sim (eu mesmo esqueço as vezes, vejo essa checkbox aqui e rodo)
- [ ] Não

# Objetivo:
`Qual o propósito / escopo dessas alterações?`

- resolve #75 

# Solução:
`Quais estratégias foram adotadas durante as alterações em questão?`

- Criação da classe `Page` para definir contrato das respostas paginadas no frontend;
- Atualizar funções `getPartners` e `getUsers` para que recebam respostas paginadas do backend;
- Atualizar views `ListPartner` e `ListUser` para utilizarem as funções service (estavam chamando `fetch` direto);
  - Usar as informações de página retornadas das funções service para atualizar dados da `Table`; 